### PR TITLE
fix parser to work well without any instanciation

### DIFF
--- a/lib/Text/LTSV.pm
+++ b/lib/Text/LTSV.pm
@@ -44,8 +44,8 @@ sub has_ignores {
 sub parse_line {
     my ($self, $line) = @_;
     chomp $line;
-    my $has_wants   = $self->has_wants;
-    my $has_ignores = $self->has_ignores;
+    my $has_wants   = ref $self ? $self->has_wants : undef;
+    my $has_ignores = ref $self ? $self->has_ignores : undef;
 
     my %wants;
     if ($has_wants) {
@@ -58,7 +58,7 @@ sub parse_line {
     }
 
     my %kv;
-    if ($self->ordered) {
+    if (ref $self and $self->ordered) {
         require Tie::IxHash;
         tie %kv, 'Tie::IxHash';
     }
@@ -72,6 +72,7 @@ sub parse_line {
 
 sub parse_file {
     my ($self, $path, $opt) = @_;
+    $self = $self->new unless ref $self;
     $opt ||= {};
     my $fh = IO::File->new($path, $opt->{utf8} ? '<:utf8' : 'r') or croak $!;
     my @out;
@@ -89,6 +90,7 @@ sub parse_file_utf8 {
 
 sub parse_file_iter {
     my ($self, $path, $opt) = @_;
+    $self = $self->new unless ref $self;
     $opt ||= {};
     my $fh = IO::File->new($path, $opt->{utf8} ? '<:utf8' : 'r') or croak $!;
     return Text::LTSV::Iterator->new($self, $fh);

--- a/t/01_parse_line.t
+++ b/t/01_parse_line.t
@@ -1,5 +1,5 @@
 use strict;
-use Test::More tests => 10;
+use Test::More tests => 11;
 
 use Text::LTSV;
 
@@ -11,6 +11,13 @@ use Text::LTSV;
     is $hash->{time}, '20:30:58';
 }
 
+{
+    my $p = Text::LTSV->new;
+    my $hash1 = $p->parse_line("hoge:foo\tbar:baz\ttime:20:30:58\n");
+
+    my $hash2 = Text::LTSV->parse_line("hoge:foo\tbar:baz\ttime:20:30:58\n");
+    is_deeply $hash2, $hash1
+}
 
 {
     my $p = Text::LTSV->new;

--- a/t/02_parse_file.t
+++ b/t/02_parse_file.t
@@ -1,5 +1,5 @@
 use strict;
-use Test::More tests => 13;
+use Test::More tests => 23;
 
 use utf8;
 use Text::LTSV;
@@ -19,6 +19,13 @@ my $p = Text::LTSV->new;
 }
 
 {
+    my $data1 = $p->parse_file_utf8('./t/test.ltsv');
+    my $data2 = Text::LTSV->parse_file_utf8('./t/test.ltsv');
+    is_deeply $data2->[0], $data1->[0];
+    is_deeply $data2->[1], $data1->[1];
+}
+
+{
     my $it = $p->parse_file_iter_utf8('./t/test.ltsv');
 
     ok $it->has_next;
@@ -35,4 +42,27 @@ my $p = Text::LTSV->new;
 
     ok not $it->has_next;
     ok $it->end;
+}
+
+{
+    my $it1 = $p->parse_file_iter_utf8('./t/test.ltsv');
+    my $it2 = Text::LTSV->parse_file_iter_utf8('./t/test.ltsv');
+
+    ok $it1->has_next && $it2->has_next;
+    my $hash1 = $it1->next;
+    my $hash2 = $it2->next;
+    is $hash2->{hoge}, $hash1->{hoge};
+
+    ok $it1->has_next && $it2->has_next;
+    $hash1 = $it1->next;
+    $hash2 = $it2->next;
+    is $hash2->{ruby}, $hash1->{ruby};
+
+    ok $it1->has_next && $it2->has_next;
+    $hash1 = $it1->next;
+    $hash2 = $it2->next;
+    is $hash2->{tennpura}, $hash1->{tennpura};
+
+    ok (not $it1->has_next and not $it2->has_next);
+    ok $it1->end && $it2->end;
 }


### PR DESCRIPTION
`parse_line()` and `parse_file()` should be more casual function.

``` perl
Text::LTSV->parse_line($str)
#works as same as "Text::LTSV->new->parse_line($str)"

Text::LTSV->parse_file($file)
#syntax sugar for Text::LTSV->new->parse_file($file)
```

Fixed version of `parse_line()` is not same with `Text::LTSV->new->parse_line($str)` correctly. It's because less cost  for non-`bless()`.
