### PR TITLE
Fix "Possible precedence issue with control flow operator" warning on perl-5.20.

### DIFF
--- a/lib/Text/LTSV.pm
+++ b/lib/Text/LTSV.pm
@@ -124,7 +124,8 @@ sub _open {
 
         return $fh;
     }
-    return IO::File->new($file, $opt->{utf8} ? '<:utf8' : 'r') or croak $!;
+    my $iofile = IO::File->new($file, $opt->{utf8} ? '<:utf8' : 'r') or croak $!;
+    return $iofile;
 }
 
 1;


### PR DESCRIPTION
When I use this module with perl-5.20, I got following warning:

```
Possible precedence issue with control flow operator at /usr/local/lib/perl5/site_perl/5.20/Text/LTSV.pm line 127.
```

To fix this, split "return" and low-precedence "or" operator.